### PR TITLE
Fix plugin manifest format for Claude Code compatibility

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,17 @@
+{
+  "name": "adversarial-spec",
+  "owner": {
+    "name": "zscole"
+  },
+  "metadata": {
+    "description": "Adversarial spec development through multi-model debate",
+    "version": "1.0.0"
+  },
+  "plugins": [
+    {
+      "name": "adversarial-spec",
+      "description": "Iteratively refine product specs through multi-model debate until consensus",
+      "source": "./"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,9 @@
   "name": "adversarial-spec",
   "version": "1.0.0",
   "description": "Iteratively refine product specs through multi-model debate until consensus. Claude actively participates alongside GPT, Gemini, Grok, and other models. Includes interview mode, early agreement verification, and optional Telegram integration.",
-  "author": "zscole",
+  "author": {
+    "name": "zscole"
+  },
   "repository": "https://github.com/zscole/adversarial-spec",
   "keywords": ["spec", "prd", "technical-specification", "llm", "debate", "consensus"]
 }

--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ A Claude Code plugin that iteratively refines product specifications through mul
 ## Quick Start
 
 ```bash
-# 1. Install the plugin
-claude plugin add github:zscole/adversarial-spec
+# 1. Add the marketplace and install the plugin
+claude plugin marketplace add zscole/adversarial-spec
+claude plugin install adversarial-spec
 
 # 2. Set at least one API key
 export OPENAI_API_KEY="sk-..."


### PR DESCRIPTION
## Summary
- Fixed `author` field in `plugin.json` to use object format (required by Claude Code validator)
- Added `marketplace.json` for proper marketplace registration
- Updated README install instructions to use correct `claude plugin marketplace add` command

## Test plan
- [x] Ran `claude plugin validate` - passes
- [x] Successfully installed plugin locally using the new instructions

Fixes - https://github.com/zscole/adversarial-spec/issues/2

🤖 Generated with [Claude Code](https://claude.com/claude-code)