### PR TITLE
Add AWS Bedrock support for enterprise model routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,29 @@ Check which keys are configured:
 python3 ~/.claude/skills/adversarial-spec/scripts/debate.py providers
 ```
 
+## AWS Bedrock Support
+
+For enterprise users who need to route all model calls through AWS Bedrock (e.g., for security compliance or inference gateway requirements):
+
+```bash
+# Enable Bedrock mode
+python3 ~/.claude/skills/adversarial-spec/scripts/debate.py bedrock enable --region us-east-1
+
+# Add models enabled in your Bedrock account
+python3 ~/.claude/skills/adversarial-spec/scripts/debate.py bedrock add-model claude-3-sonnet
+python3 ~/.claude/skills/adversarial-spec/scripts/debate.py bedrock add-model claude-3-haiku
+
+# Check configuration
+python3 ~/.claude/skills/adversarial-spec/scripts/debate.py bedrock status
+
+# Disable Bedrock mode
+python3 ~/.claude/skills/adversarial-spec/scripts/debate.py bedrock disable
+```
+
+When Bedrock is enabled, **all model calls route through Bedrock** - no direct API calls are made. Use friendly names like `claude-3-sonnet` which are automatically mapped to Bedrock model IDs.
+
+Configuration is stored at `~/.claude/adversarial-spec/config.json`.
+
 ## Usage
 
 **Start from scratch:**
@@ -395,6 +418,14 @@ debate.py sessions       # List saved sessions
 
 # Profile management
 debate.py save-profile NAME --models ... [--focus ...] [--persona ...]
+
+# Bedrock management
+debate.py bedrock status                      # Show Bedrock configuration
+debate.py bedrock enable --region REGION      # Enable Bedrock mode
+debate.py bedrock disable                     # Disable Bedrock mode
+debate.py bedrock add-model MODEL             # Add model to available list
+debate.py bedrock remove-model MODEL          # Remove model from list
+debate.py bedrock list-models                 # List built-in model mappings
 ```
 
 **Options:**

--- a/skills/adversarial-spec/SKILL.md
+++ b/skills/adversarial-spec/SKILL.md
@@ -13,7 +13,7 @@ Generate and refine specifications through iterative debate with multiple LLMs u
 ## Requirements
 
 - Python 3.10+ with `litellm` package installed
-- API key for at least one provider (set via environment variable)
+- API key for at least one provider (set via environment variable), OR AWS Bedrock configured
 
 ## Supported Providers
 
@@ -28,6 +28,61 @@ Generate and refine specifications through iterative debate with multiple LLMs u
 | Deepseek  | `DEEPSEEK_API_KEY`   | `deepseek/deepseek-chat`                    |
 
 Run `python3 ~/.claude/skills/adversarial-spec/scripts/debate.py providers` to see which keys are set.
+
+## AWS Bedrock Support
+
+For enterprise users who need to route all model calls through AWS Bedrock (e.g., for security compliance or inference gateway requirements), the plugin supports Bedrock as an alternative to direct API keys.
+
+**When Bedrock mode is enabled, ALL model calls route through Bedrock** - no direct API calls are made.
+
+### Bedrock Setup
+
+To enable Bedrock mode, use these CLI commands (Claude can invoke these when the user requests Bedrock setup):
+
+```bash
+# Enable Bedrock mode with a region
+python3 ~/.claude/skills/adversarial-spec/scripts/debate.py bedrock enable --region us-east-1
+
+# Add models that are enabled in your Bedrock account
+python3 ~/.claude/skills/adversarial-spec/scripts/debate.py bedrock add-model claude-3-sonnet
+python3 ~/.claude/skills/adversarial-spec/scripts/debate.py bedrock add-model claude-3-haiku
+
+# Check current configuration
+python3 ~/.claude/skills/adversarial-spec/scripts/debate.py bedrock status
+
+# Disable Bedrock mode (revert to direct API keys)
+python3 ~/.claude/skills/adversarial-spec/scripts/debate.py bedrock disable
+```
+
+### Bedrock Model Names
+
+Users can specify models using friendly names (e.g., `claude-3-sonnet`), which are automatically mapped to Bedrock model IDs. Built-in mappings include:
+
+- `claude-3-sonnet`, `claude-3-haiku`, `claude-3-opus`, `claude-3.5-sonnet`
+- `llama-3-8b`, `llama-3-70b`, `llama-3.1-70b`, `llama-3.1-405b`
+- `mistral-7b`, `mistral-large`, `mixtral-8x7b`
+- `cohere-command`, `cohere-command-r`, `cohere-command-r-plus`
+
+Run `python3 ~/.claude/skills/adversarial-spec/scripts/debate.py bedrock list-models` to see all mappings.
+
+### Bedrock Configuration Location
+
+Configuration is stored at `~/.claude/adversarial-spec/config.json`:
+
+```json
+{
+  "bedrock": {
+    "enabled": true,
+    "region": "us-east-1",
+    "available_models": ["claude-3-sonnet", "claude-3-haiku"],
+    "custom_aliases": {}
+  }
+}
+```
+
+### Bedrock Error Handling
+
+If a Bedrock model fails (e.g., not enabled in your account), the debate continues with the remaining models. Clear error messages indicate which models failed and why.
 
 ## Document Types
 


### PR DESCRIPTION
- Add Bedrock mode that routes ALL model calls through AWS Bedrock
- Add friendly name mapping (e.g., claude-3-sonnet -> full Bedrock ID)
- Add bedrock CLI subcommands: status, enable, disable, add-model, remove-model, list-models
- Add config storage at ~/.claude/adversarial-spec/config.json
- Add skip-and-warn error handling for Bedrock-specific errors
- Update providers command to show Bedrock status
- Add documentation to SKILL.md and README.md

Key design decisions:
- All-or-nothing: when Bedrock enabled, all models route through Bedrock
- Two-level model config: available_models in config, active selection per-session
- Standard AWS credential chain (env vars, profile, IAM role)