### PR TITLE
feat: Add OpenRouter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ claude plugin install adversarial-spec
 
 # 2. Set at least one API key
 export OPENAI_API_KEY="sk-..."
+# Or use OpenRouter for access to multiple providers with one key
+export OPENROUTER_API_KEY="sk-or-..."
 
 # 3. Run it
 /adversarial-spec "Build a rate limiter service with Redis backend"
@@ -57,15 +59,16 @@ You describe product --> Claude drafts spec --> Multiple LLMs critique in parall
 
 ## Supported Models
 
-| Provider  | Env Var              | Example Models                               |
-|-----------|----------------------|----------------------------------------------|
-| OpenAI    | `OPENAI_API_KEY`     | `gpt-4o`, `gpt-4-turbo`, `o1`                |
-| Google    | `GEMINI_API_KEY`     | `gemini/gemini-2.0-flash`, `gemini/gemini-pro` |
-| xAI       | `XAI_API_KEY`        | `xai/grok-3`, `xai/grok-beta`                |
-| Mistral   | `MISTRAL_API_KEY`    | `mistral/mistral-large`, `mistral/codestral` |
-| Groq      | `GROQ_API_KEY`       | `groq/llama-3.3-70b-versatile`               |
-| Deepseek  | `DEEPSEEK_API_KEY`   | `deepseek/deepseek-chat`                     |
-| Zhipu     | `ZHIPUAI_API_KEY`    | `zhipu/glm-4`, `zhipu/glm-4-plus`            |
+| Provider   | Env Var                | Example Models                               |
+|------------|------------------------|----------------------------------------------|
+| OpenAI     | `OPENAI_API_KEY`       | `gpt-4o`, `gpt-4-turbo`, `o1`                |
+| Google     | `GEMINI_API_KEY`       | `gemini/gemini-2.0-flash`, `gemini/gemini-pro` |
+| xAI        | `XAI_API_KEY`          | `xai/grok-3`, `xai/grok-beta`                |
+| Mistral    | `MISTRAL_API_KEY`      | `mistral/mistral-large`, `mistral/codestral` |
+| Groq       | `GROQ_API_KEY`         | `groq/llama-3.3-70b-versatile`               |
+| OpenRouter | `OPENROUTER_API_KEY`   | `openrouter/openai/gpt-4o`, `openrouter/anthropic/claude-3.5-sonnet` |
+| Deepseek   | `DEEPSEEK_API_KEY`     | `deepseek/deepseek-chat`                     |
+| Zhipu      | `ZHIPUAI_API_KEY`      | `zhipu/glm-4`, `zhipu/glm-4-plus`            |
 
 Check which keys are configured:
 
@@ -95,6 +98,33 @@ python3 ~/.claude/skills/adversarial-spec/scripts/debate.py bedrock disable
 When Bedrock is enabled, **all model calls route through Bedrock** - no direct API calls are made. Use friendly names like `claude-3-sonnet` which are automatically mapped to Bedrock model IDs.
 
 Configuration is stored at `~/.claude/adversarial-spec/config.json`.
+
+## OpenRouter Support
+
+[OpenRouter](https://openrouter.ai) provides unified access to multiple LLM providers through a single API. This is useful for:
+- Accessing models from multiple providers with one API key
+- Comparing models across different providers
+- Automatic fallback and load balancing
+- Cost optimization across providers
+
+**Setup:**
+
+```bash
+# Get your API key from https://openrouter.ai/keys
+export OPENROUTER_API_KEY="sk-or-..."
+
+# Use OpenRouter models (prefix with openrouter/)
+python3 debate.py critique --models openrouter/openai/gpt-4o,openrouter/anthropic/claude-3.5-sonnet < spec.md
+```
+
+**Popular OpenRouter models:**
+- `openrouter/openai/gpt-4o` - GPT-4o via OpenRouter
+- `openrouter/anthropic/claude-3.5-sonnet` - Claude 3.5 Sonnet
+- `openrouter/google/gemini-2.0-flash` - Gemini 2.0 Flash
+- `openrouter/meta-llama/llama-3.3-70b-instruct` - Llama 3.3 70B
+- `openrouter/qwen/qwen-2.5-72b-instruct` - Qwen 2.5 72B
+
+See the full model list at [openrouter.ai/models](https://openrouter.ai/models).
 
 ## OpenAI-Compatible Endpoints
 

--- a/skills/adversarial-spec/SKILL.md
+++ b/skills/adversarial-spec/SKILL.md
@@ -17,17 +17,18 @@ Generate and refine specifications through iterative debate with multiple LLMs u
 
 ## Supported Providers
 
-| Provider  | API Key Env Var      | Example Models                              |
-|-----------|----------------------|---------------------------------------------|
-| OpenAI    | `OPENAI_API_KEY`     | `gpt-5.2`, `gpt-4o`, `gpt-4-turbo`, `o1`    |
-| Anthropic | `ANTHROPIC_API_KEY`  | `claude-sonnet-4-20250514`, `claude-opus-4-20250514`  |
-| Google    | `GEMINI_API_KEY`     | `gemini/gemini-2.0-flash`, `gemini/gemini-pro` |
-| xAI       | `XAI_API_KEY`        | `xai/grok-3`, `xai/grok-beta`               |
-| Mistral   | `MISTRAL_API_KEY`    | `mistral/mistral-large`, `mistral/codestral`|
-| Groq      | `GROQ_API_KEY`       | `groq/llama-3.3-70b-versatile`              |
-| Deepseek  | `DEEPSEEK_API_KEY`   | `deepseek/deepseek-chat`                    |
-| Zhipu     | `ZHIPUAI_API_KEY`    | `zhipu/glm-4`, `zhipu/glm-4-plus`           |
-| Codex CLI | (ChatGPT subscription) | `codex/gpt-5.2-codex`, `codex/gpt-5.1-codex-max` |
+| Provider   | API Key Env Var        | Example Models                              |
+|------------|------------------------|---------------------------------------------|
+| OpenAI     | `OPENAI_API_KEY`       | `gpt-5.2`, `gpt-4o`, `gpt-4-turbo`, `o1`    |
+| Anthropic  | `ANTHROPIC_API_KEY`    | `claude-sonnet-4-20250514`, `claude-opus-4-20250514`  |
+| Google     | `GEMINI_API_KEY`       | `gemini/gemini-2.0-flash`, `gemini/gemini-pro` |
+| xAI        | `XAI_API_KEY`          | `xai/grok-3`, `xai/grok-beta`               |
+| Mistral    | `MISTRAL_API_KEY`      | `mistral/mistral-large`, `mistral/codestral`|
+| Groq       | `GROQ_API_KEY`         | `groq/llama-3.3-70b-versatile`              |
+| OpenRouter | `OPENROUTER_API_KEY`   | `openrouter/openai/gpt-4o`, `openrouter/anthropic/claude-3.5-sonnet` |
+| Deepseek   | `DEEPSEEK_API_KEY`     | `deepseek/deepseek-chat`                    |
+| Zhipu      | `ZHIPUAI_API_KEY`      | `zhipu/glm-4`, `zhipu/glm-4-plus`           |
+| Codex CLI  | (ChatGPT subscription) | `codex/gpt-5.2-codex`, `codex/gpt-5.1-codex-max` |
 
 **Codex CLI Setup:**
 - Install: `npm install -g @openai/codex && codex login`

--- a/skills/adversarial-spec/scripts/debate.py
+++ b/skills/adversarial-spec/scripts/debate.py
@@ -21,15 +21,16 @@ Usage:
     python3 debate.py sessions
 
 Supported providers (set corresponding API key):
-    OpenAI:    OPENAI_API_KEY      models: gpt-4o, gpt-4-turbo, o1, etc.
-    Anthropic: ANTHROPIC_API_KEY   models: claude-sonnet-4-20250514, claude-opus-4-20250514, etc.
-    Google:    GEMINI_API_KEY      models: gemini/gemini-2.0-flash, gemini/gemini-pro, etc.
-    xAI:       XAI_API_KEY         models: xai/grok-3, xai/grok-beta, etc.
-    Mistral:   MISTRAL_API_KEY     models: mistral/mistral-large, etc.
-    Groq:      GROQ_API_KEY        models: groq/llama-3.3-70b, etc.
-    Codex CLI: (ChatGPT subscription) models: codex/gpt-5.2-codex, codex/gpt-5.1-codex-max
-               Install: npm install -g @openai/codex && codex login
-               Reasoning: --codex-reasoning xhigh (minimal, low, medium, high, xhigh)
+    OpenAI:     OPENAI_API_KEY       models: gpt-4o, gpt-4-turbo, o1, etc.
+    Anthropic:  ANTHROPIC_API_KEY    models: claude-sonnet-4-20250514, claude-opus-4-20250514, etc.
+    Google:     GEMINI_API_KEY       models: gemini/gemini-2.0-flash, gemini/gemini-pro, etc.
+    xAI:        XAI_API_KEY          models: xai/grok-3, xai/grok-beta, etc.
+    Mistral:    MISTRAL_API_KEY      models: mistral/mistral-large, etc.
+    Groq:       GROQ_API_KEY         models: groq/llama-3.3-70b, etc.
+    OpenRouter: OPENROUTER_API_KEY   models: openrouter/openai/gpt-4o, openrouter/anthropic/claude-3.5-sonnet, etc.
+    Codex CLI:  (ChatGPT subscription) models: codex/gpt-5.2-codex, codex/gpt-5.1-codex-max
+                Install: npm install -g @openai/codex && codex login
+                Reasoning: --codex-reasoning xhigh (minimal, low, medium, high, xhigh)
 
 Document types:
     prd   - Product Requirements Document (business/product focus)

--- a/skills/adversarial-spec/scripts/providers.py
+++ b/skills/adversarial-spec/scripts/providers.py
@@ -277,6 +277,7 @@ def list_providers():
         ("Mistral", "MISTRAL_API_KEY", "mistral/mistral-large, mistral/codestral"),
         ("Groq", "GROQ_API_KEY", "groq/llama-3.3-70b-versatile"),
         ("Together", "TOGETHER_API_KEY", "together_ai/meta-llama/Llama-3-70b"),
+        ("OpenRouter", "OPENROUTER_API_KEY", "openrouter/openai/gpt-4o, openrouter/anthropic/claude-3.5-sonnet"),
         ("Deepseek", "DEEPSEEK_API_KEY", "deepseek/deepseek-chat"),
         ("Zhipu", "ZHIPUAI_API_KEY", "zhipu/glm-4, zhipu/glm-4-plus"),
     ]


### PR DESCRIPTION
Adds OpenRouter support, enabling access to 300+ models through a single API key.

Closes #9

## Changes
- Added OpenRouter to providers list
- Updated providers command output
- Added OpenRouter documentation section to README
- Updated SKILL.md

## Tested
- python3 debate.py providers shows OpenRouter [set]
- LiteLLM successfully calls openrouter/openai/gpt-4o-mini