### PR TITLE
feat: add Gemini CLI support (without using api key)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ You describe product --> Claude drafts spec --> Multiple LLMs critique in parall
 | Groq       | `GROQ_API_KEY`         | `groq/llama-3.3-70b-versatile`               |
 | OpenRouter | `OPENROUTER_API_KEY`   | `openrouter/openai/gpt-4o`, `openrouter/anthropic/claude-3.5-sonnet` |
 | Codex CLI  | ChatGPT subscription   | `codex/gpt-5.2-codex`, `codex/gpt-5.1-codex-max` |
+| Gemini CLI | Google account         | `gemini-cli/gemini-3-pro-preview`, `gemini-cli/gemini-3-flash-preview` |
 | Deepseek   | `DEEPSEEK_API_KEY`     | `deepseek/deepseek-chat`                     |
 | Zhipu      | `ZHIPUAI_API_KEY`      | `zhipu/glm-4`, `zhipu/glm-4-plus`            |
 
@@ -158,6 +159,30 @@ Higher reasoning effort produces more thorough analysis but uses more tokens.
 - `codex/gpt-5.1-codex-max` - GPT-5.1 Max via Codex CLI
 
 Check Codex CLI installation status:
+
+```bash
+python3 ~/.claude/skills/adversarial-spec/scripts/debate.py providers
+```
+
+## Gemini CLI Support
+
+[Gemini CLI](https://github.com/google-gemini/gemini-cli) allows Google account holders to use Gemini models without separate API credits. Models prefixed with `gemini-cli/` are routed through the Gemini CLI.
+
+**Setup:**
+
+```bash
+# Install Gemini CLI
+npm install -g @google/gemini-cli && gemini auth
+
+# Use Gemini CLI models (prefix with gemini-cli/)
+python3 debate.py critique --models gemini-cli/gemini-3-pro-preview < spec.md
+```
+
+**Available Gemini CLI models:**
+- `gemini-cli/gemini-3-pro-preview` - Gemini 3 Pro via CLI
+- `gemini-cli/gemini-3-flash-preview` - Gemini 3 Flash via CLI
+
+Check Gemini CLI installation status:
 
 ```bash
 python3 ~/.claude/skills/adversarial-spec/scripts/debate.py providers

--- a/skills/adversarial-spec/SKILL.md
+++ b/skills/adversarial-spec/SKILL.md
@@ -13,7 +13,9 @@ Generate and refine specifications through iterative debate with multiple LLMs u
 ## Requirements
 
 - Python 3.10+ with `litellm` package installed
-- API key for at least one provider (set via environment variable), OR AWS Bedrock configured
+- API key for at least one provider (set via environment variable), OR AWS Bedrock configured, OR CLI tools (codex, gemini) installed
+
+**IMPORTANT: Do NOT install the `llm` package (Simon Willison's tool).** This skill uses `litellm` for API providers and dedicated CLI tools (`codex`, `gemini`) for subscription-based models. Installing `llm` is unnecessary and may cause confusion.
 
 ## Supported Providers
 
@@ -29,11 +31,17 @@ Generate and refine specifications through iterative debate with multiple LLMs u
 | Deepseek   | `DEEPSEEK_API_KEY`     | `deepseek/deepseek-chat`                    |
 | Zhipu      | `ZHIPUAI_API_KEY`      | `zhipu/glm-4`, `zhipu/glm-4-plus`           |
 | Codex CLI  | (ChatGPT subscription) | `codex/gpt-5.2-codex`, `codex/gpt-5.1-codex-max` |
+| Gemini CLI | (Google account)       | `gemini-cli/gemini-3-pro-preview`, `gemini-cli/gemini-3-flash-preview` |
 
 **Codex CLI Setup:**
 - Install: `npm install -g @openai/codex && codex login`
 - Reasoning effort: `--codex-reasoning` (minimal, low, medium, high, xhigh)
 - Web search: `--codex-search` (enables web search for current information)
+
+**Gemini CLI Setup:**
+- Install: `npm install -g @google/gemini-cli && gemini auth`
+- Models: `gemini-3-pro-preview`, `gemini-3-flash-preview`
+- No API key needed - uses Google account authentication
 
 Run `python3 ~/.claude/skills/adversarial-spec/scripts/debate.py providers` to see which keys are set.
 
@@ -330,6 +338,13 @@ Then present available models to the user using AskUserQuestion with multiSelect
 **If ZHIPUAI_API_KEY is set, include:**
 - `zhipu/glm-4` - Chinese language model
 - `zhipu/glm-4-plus` - Enhanced GLM model
+
+**If Codex CLI is installed, include:**
+- `codex/gpt-5.2-codex` - OpenAI Codex with extended reasoning
+
+**If Gemini CLI is installed, include:**
+- `gemini-cli/gemini-3-pro-preview` - Google Gemini 3 Pro
+- `gemini-cli/gemini-3-flash-preview` - Google Gemini 3 Flash
 
 Use AskUserQuestion like this:
 ```

--- a/test-spec.md
+++ b/test-spec.md
@@ -1,0 +1,43 @@
+# Technical Specification: User Authentication API
+
+## Overview
+A simple REST API for user authentication with JWT tokens.
+
+## Goals
+- Allow users to register and login
+- Issue JWT tokens for authenticated sessions
+- Support password reset via email
+
+## API Endpoints
+
+### POST /auth/register
+Request: `{ "email": string, "password": string }`
+Response: `{ "userId": string, "token": string }`
+
+### POST /auth/login
+Request: `{ "email": string, "password": string }`
+Response: `{ "token": string, "expiresIn": number }`
+
+### POST /auth/reset-password
+Request: `{ "email": string }`
+Response: `{ "message": string }`
+
+## Data Model
+
+```sql
+CREATE TABLE users (
+  id UUID PRIMARY KEY,
+  email VARCHAR(255) UNIQUE NOT NULL,
+  password_hash VARCHAR(255) NOT NULL,
+  created_at TIMESTAMP DEFAULT NOW()
+);
+```
+
+## Security
+- Passwords hashed with bcrypt
+- JWT tokens expire in 24 hours
+- Rate limiting: 10 requests per minute per IP
+
+## Open Questions
+- Should we support OAuth providers?
+- What's the token refresh strategy?


### PR DESCRIPTION
Add support for Google's Gemini CLI as a new provider option:

- Add gemini-cli/gemini-3-pro-preview and gemini-cli/gemini-3-flash-preview models
- Add GEMINI_CLI_AVAILABLE detection
- Add call_gemini_cli_model() function in models.py
- Add Gemini CLI to list_providers output
- Update SKILL.md with Gemini CLI setup instructions

Install: npm install -g @google/gemini-cli && gemini auth

Uses Google account authentication (no API key needed).