### PR TITLE
feat: add Claude CLI support

### DIFF
--- a/skills/adversarial-spec/SKILL.md
+++ b/skills/adversarial-spec/SKILL.md
@@ -13,9 +13,9 @@ Generate and refine specifications through iterative debate with multiple LLMs u
 ## Requirements
 
 - Python 3.10+ with `litellm` package installed
-- API key for at least one provider (set via environment variable), OR AWS Bedrock configured, OR CLI tools (codex, claude, gemini) installed
+- API key for at least one provider (set via environment variable), OR AWS Bedrock configured, OR CLI tools (codex, gemini) installed
 
-**IMPORTANT: Do NOT install the `llm` package (Simon Willison's tool).** This skill uses `litellm` for API providers and dedicated CLI tools (`codex`, `claude`, `gemini`) for subscription-based models. Installing `llm` is unnecessary and may cause confusion.
+**IMPORTANT: Do NOT install the `llm` package (Simon Willison's tool).** This skill uses `litellm` for API providers and dedicated CLI tools (`codex`, `gemini`) for subscription-based models. Installing `llm` is unnecessary and may cause confusion.
 
 ## Supported Providers
 
@@ -31,18 +31,12 @@ Generate and refine specifications through iterative debate with multiple LLMs u
 | Deepseek   | `DEEPSEEK_API_KEY`     | `deepseek/deepseek-chat`                    |
 | Zhipu      | `ZHIPUAI_API_KEY`      | `zhipu/glm-4`, `zhipu/glm-4-plus`           |
 | Codex CLI  | (ChatGPT subscription) | `codex/gpt-5.2-codex`, `codex/gpt-5.1-codex-max` |
-| Claude CLI | (Claude account)       | `claude-cli/sonnet`, `claude-cli/opus`      |
 | Gemini CLI | (Google account)       | `gemini-cli/gemini-3-pro-preview`, `gemini-cli/gemini-3-flash-preview` |
 
 **Codex CLI Setup:**
 - Install: `npm install -g @openai/codex && codex login`
 - Reasoning effort: `--codex-reasoning` (minimal, low, medium, high, xhigh)
 - Web search: `--codex-search` (enables web search for current information)
-
-**Claude CLI Setup:**
-- Install: `npm install -g @anthropic-ai/claude-code && claude`
-- Models: `sonnet`, `opus`, `haiku` (prefix with `claude-cli/` in this tool)
-- No API key needed - uses Claude account authentication
 
 **Gemini CLI Setup:**
 - Install: `npm install -g @google/gemini-cli && gemini auth`
@@ -348,10 +342,6 @@ Then present available models to the user using AskUserQuestion with multiSelect
 **If Codex CLI is installed, include:**
 - `codex/gpt-5.2-codex` - OpenAI Codex with extended reasoning
 
-**If Claude CLI is installed, include:**
-- `claude-cli/sonnet` - Strong reasoning, good balance
-- `claude-cli/opus` - Highest capability
-
 **If Gemini CLI is installed, include:**
 - `gemini-cli/gemini-3-pro-preview` - Google Gemini 3 Pro
 - `gemini-cli/gemini-3-flash-preview` - Google Gemini 3 Flash
@@ -365,8 +355,6 @@ options: [only include models whose API keys are configured]
 ```
 
 More models = more perspectives = stricter convergence.
-
-Defaults: If no `--models` are provided, the script prefers `codex/gpt-5.2-codex` + `claude-cli/sonnet` when those CLIs are installed; otherwise it falls back to the first available API provider.
 
 ### Step 3: Send to Opponent Models for Critique
 

--- a/skills/adversarial-spec/SKILL.md
+++ b/skills/adversarial-spec/SKILL.md
@@ -13,9 +13,9 @@ Generate and refine specifications through iterative debate with multiple LLMs u
 ## Requirements
 
 - Python 3.10+ with `litellm` package installed
-- API key for at least one provider (set via environment variable), OR AWS Bedrock configured, OR CLI tools (codex, gemini) installed
+- API key for at least one provider (set via environment variable), OR AWS Bedrock configured, OR CLI tools (codex, claude, gemini) installed
 
-**IMPORTANT: Do NOT install the `llm` package (Simon Willison's tool).** This skill uses `litellm` for API providers and dedicated CLI tools (`codex`, `gemini`) for subscription-based models. Installing `llm` is unnecessary and may cause confusion.
+**IMPORTANT: Do NOT install the `llm` package (Simon Willison's tool).** This skill uses `litellm` for API providers and dedicated CLI tools (`codex`, `claude`, `gemini`) for subscription-based models. Installing `llm` is unnecessary and may cause confusion.
 
 ## Supported Providers
 
@@ -31,12 +31,18 @@ Generate and refine specifications through iterative debate with multiple LLMs u
 | Deepseek   | `DEEPSEEK_API_KEY`     | `deepseek/deepseek-chat`                    |
 | Zhipu      | `ZHIPUAI_API_KEY`      | `zhipu/glm-4`, `zhipu/glm-4-plus`           |
 | Codex CLI  | (ChatGPT subscription) | `codex/gpt-5.2-codex`, `codex/gpt-5.1-codex-max` |
+| Claude CLI | (Claude account)       | `claude-cli/sonnet`, `claude-cli/opus`      |
 | Gemini CLI | (Google account)       | `gemini-cli/gemini-3-pro-preview`, `gemini-cli/gemini-3-flash-preview` |
 
 **Codex CLI Setup:**
 - Install: `npm install -g @openai/codex && codex login`
 - Reasoning effort: `--codex-reasoning` (minimal, low, medium, high, xhigh)
 - Web search: `--codex-search` (enables web search for current information)
+
+**Claude CLI Setup:**
+- Install: `npm install -g @anthropic-ai/claude-code && claude`
+- Models: `sonnet`, `opus`, `haiku` (prefix with `claude-cli/` in this tool)
+- No API key needed - uses Claude account authentication
 
 **Gemini CLI Setup:**
 - Install: `npm install -g @google/gemini-cli && gemini auth`
@@ -342,6 +348,10 @@ Then present available models to the user using AskUserQuestion with multiSelect
 **If Codex CLI is installed, include:**
 - `codex/gpt-5.2-codex` - OpenAI Codex with extended reasoning
 
+**If Claude CLI is installed, include:**
+- `claude-cli/sonnet` - Strong reasoning, good balance
+- `claude-cli/opus` - Highest capability
+
 **If Gemini CLI is installed, include:**
 - `gemini-cli/gemini-3-pro-preview` - Google Gemini 3 Pro
 - `gemini-cli/gemini-3-flash-preview` - Google Gemini 3 Flash
@@ -355,6 +365,8 @@ options: [only include models whose API keys are configured]
 ```
 
 More models = more perspectives = stricter convergence.
+
+Defaults: If no `--models` are provided, the script prefers `codex/gpt-5.2-codex` + `claude-cli/sonnet` when those CLIs are installed; otherwise it falls back to the first available API provider.
 
 ### Step 3: Send to Opponent Models for Critique
 

--- a/skills/adversarial-spec/scripts/debate.py
+++ b/skills/adversarial-spec/scripts/debate.py
@@ -31,6 +31,8 @@ Supported providers (set corresponding API key):
     Codex CLI:  (ChatGPT subscription) models: codex/gpt-5.2-codex, codex/gpt-5.1-codex-max
                 Install: npm install -g @openai/codex && codex login
                 Reasoning: --codex-reasoning xhigh (minimal, low, medium, high, xhigh)
+    Claude CLI: (Claude account)       models: claude-cli/sonnet, claude-cli/opus
+                Install: npm install -g @anthropic-ai/claude-code && claude
 
 Document types:
     prd   - Product Requirements Document (business/product focus)

--- a/skills/adversarial-spec/scripts/models.py
+++ b/skills/adversarial-spec/scripts/models.py
@@ -36,6 +36,7 @@ from prompts import (
     get_system_prompt,
 )
 from providers import (
+    CLAUDE_CLI_AVAILABLE,
     CODEX_AVAILABLE,
     DEFAULT_CODEX_REASONING,
     DEFAULT_COST,
@@ -370,6 +371,70 @@ USER REQUEST:
         raise RuntimeError("Codex CLI not found in PATH")
 
 
+def call_claude_cli_model(
+    system_prompt: str,
+    user_message: str,
+    model: str,
+    timeout: int = 600,
+) -> tuple[str, int, int]:
+    """
+    Call Claude CLI in print mode.
+
+    Args:
+        system_prompt: System instructions for the model
+        user_message: User prompt to send
+        model: Model name (e.g., "claude-cli/sonnet" -> uses "sonnet")
+        timeout: Timeout in seconds (default 10 minutes)
+
+    Returns:
+        Tuple of (response_text, input_tokens, output_tokens)
+
+    Raises:
+        RuntimeError: If Claude CLI is not available or fails
+    """
+    if not CLAUDE_CLI_AVAILABLE:
+        raise RuntimeError(
+            "Claude CLI not found. Install with: npm install -g @anthropic-ai/claude-code"
+        )
+
+    actual_model = model.split("/", 1)[1] if "/" in model else model
+
+    try:
+        cmd = [
+            "claude",
+            "-p",
+            "--output-format",
+            "text",
+            "--model",
+            actual_model,
+            "--append-system-prompt",
+            system_prompt,
+            user_message,
+        ]
+
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+
+        if result.returncode != 0:
+            error_msg = (
+                result.stderr.strip() or f"Claude CLI exited with code {result.returncode}"
+            )
+            raise RuntimeError(f"Claude CLI failed: {error_msg}")
+
+        response_text = result.stdout.strip()
+        if not response_text:
+            raise RuntimeError("No response from Claude CLI")
+
+        input_tokens = (len(system_prompt) + len(user_message)) // 4
+        output_tokens = len(response_text) // 4
+
+        return response_text, input_tokens, output_tokens
+
+    except subprocess.TimeoutExpired:
+        raise RuntimeError(f"Claude CLI timed out after {timeout}s")
+    except FileNotFoundError:
+        raise RuntimeError("Claude CLI not found in PATH")
+
+
 def call_gemini_cli_model(
     system_prompt: str,
     user_message: str,
@@ -560,6 +625,56 @@ def call_single_model(
         for attempt in range(MAX_RETRIES):
             try:
                 content, input_tokens, output_tokens = call_gemini_cli_model(
+                    system_prompt=system_prompt,
+                    user_message=user_message,
+                    model=model,
+                    timeout=timeout,
+                )
+                agreed = "[AGREE]" in content
+                extracted = extract_spec(content)
+
+                if not agreed and not extracted:
+                    print(
+                        f"Warning: {model} provided critique but no [SPEC] tags found. Response may be malformed.",
+                        file=sys.stderr,
+                    )
+
+                cost = cost_tracker.add(model, input_tokens, output_tokens)
+
+                return ModelResponse(
+                    model=model,
+                    response=content,
+                    agreed=agreed,
+                    spec=extracted,
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                    cost=cost,
+                )
+            except Exception as e:
+                last_error = str(e)
+                if attempt < MAX_RETRIES - 1:
+                    delay = RETRY_BASE_DELAY * (2**attempt)
+                    print(
+                        f"Warning: {model} failed (attempt {attempt + 1}/{MAX_RETRIES}): {last_error}. Retrying in {delay:.1f}s...",
+                        file=sys.stderr,
+                    )
+                    time.sleep(delay)
+                else:
+                    print(
+                        f"Error: {model} failed after {MAX_RETRIES} attempts: {last_error}",
+                        file=sys.stderr,
+                    )
+
+        return ModelResponse(
+            model=model, response="", agreed=False, spec=None, error=last_error
+        )
+
+    # Route Claude CLI models to dedicated handler
+    if model.startswith("claude-cli/"):
+        last_error = None
+        for attempt in range(MAX_RETRIES):
+            try:
+                content, input_tokens, output_tokens = call_claude_cli_model(
                     system_prompt=system_prompt,
                     user_message=user_message,
                     model=model,


### PR DESCRIPTION
## Summary
- extract Claude CLI support from mixed fixture/Claude changes
- add Claude CLI provider discovery, model validation, and default selection
- route `claude-cli/*` models through dedicated CLI invocation in debate runner
- add docs and tests for Claude CLI behavior

## Notes
- fixture-specific baseline/default context changes were intentionally excluded

## Verification
- `.venv/bin/python -m pytest skills/adversarial-spec/scripts/tests/test_models.py skills/adversarial-spec/scripts/tests/test_providers.py`
