### PR TITLE
feat: add gpt-5.3-codex model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- New `codex/gpt-5.3-codex` model support for Codex CLI (ChatGPT subscription)
+- Updated default Codex CLI model from `gpt-5.2-codex` to `gpt-5.3-codex`
+
 ### Fixed
 
 - Added `--skip-git-repo-check` flag to Codex CLI calls for non-git directory support

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ You describe product --> Claude drafts spec --> Multiple LLMs critique in parall
 | Mistral    | `MISTRAL_API_KEY`      | `mistral/mistral-large`, `mistral/codestral` |
 | Groq       | `GROQ_API_KEY`         | `groq/llama-3.3-70b-versatile`               |
 | OpenRouter | `OPENROUTER_API_KEY`   | `openrouter/openai/gpt-4o`, `openrouter/anthropic/claude-3.5-sonnet` |
-| Codex CLI  | ChatGPT subscription   | `codex/gpt-5.2-codex`, `codex/gpt-5.1-codex-max` |
+| Codex CLI  | ChatGPT subscription   | `codex/gpt-5.3-codex`, `codex/gpt-5.2-codex` |
 | Gemini CLI | Google account         | `gemini-cli/gemini-3-pro-preview`, `gemini-cli/gemini-3-flash-preview` |
 | Deepseek   | `DEEPSEEK_API_KEY`     | `deepseek/deepseek-chat`                     |
 | Zhipu      | `ZHIPUAI_API_KEY`      | `zhipu/glm-4`, `zhipu/glm-4-plus`            |
@@ -140,7 +140,7 @@ See the full model list at [openrouter.ai/models](https://openrouter.ai/models).
 npm install -g @openai/codex
 
 # Use Codex models (prefix with codex/)
-python3 debate.py critique --models codex/gpt-5.2-codex,gemini/gemini-2.0-flash < spec.md
+python3 debate.py critique --models codex/gpt-5.3-codex,gemini/gemini-2.0-flash < spec.md
 ```
 
 **Reasoning effort:**
@@ -149,14 +149,14 @@ Control how much thinking time the model uses with `--codex-reasoning`:
 
 ```bash
 # Available levels: low, medium, high, xhigh (default: xhigh)
-python3 debate.py critique --models codex/gpt-5.2-codex --codex-reasoning high < spec.md
+python3 debate.py critique --models codex/gpt-5.3-codex --codex-reasoning high < spec.md
 ```
 
 Higher reasoning effort produces more thorough analysis but uses more tokens.
 
 **Available Codex models:**
+- `codex/gpt-5.3-codex` - GPT-5.3 via Codex CLI
 - `codex/gpt-5.2-codex` - GPT-5.2 via Codex CLI
-- `codex/gpt-5.1-codex-max` - GPT-5.1 Max via Codex CLI
 
 Check Codex CLI installation status:
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,14 @@ Control how much thinking time the model uses with `--codex-reasoning`:
 python3 debate.py critique --models codex/gpt-5.3-codex --codex-reasoning high < spec.md
 ```
 
-Higher reasoning effort produces more thorough analysis but uses more tokens.
+| Level    | Description                                       |
+|----------|---------------------------------------------------|
+| `low`    | Fast responses with lighter reasoning              |
+| `medium` | Balances speed and reasoning depth (Codex default) |
+| `high`   | Greater reasoning depth for complex problems       |
+| `xhigh`  | Extra high reasoning depth (adversarial-spec default) |
+
+The plugin defaults to `xhigh` because adversarial spec review benefits from thorough, deep analysis. Use `medium` or `high` for faster iterations.
 
 **Available Codex models:**
 - `codex/gpt-5.3-codex` - GPT-5.3 via Codex CLI

--- a/skills/adversarial-spec/SKILL.md
+++ b/skills/adversarial-spec/SKILL.md
@@ -30,7 +30,7 @@ Generate and refine specifications through iterative debate with multiple LLMs u
 | OpenRouter | `OPENROUTER_API_KEY`   | `openrouter/openai/gpt-4o`, `openrouter/anthropic/claude-3.5-sonnet` |
 | Deepseek   | `DEEPSEEK_API_KEY`     | `deepseek/deepseek-chat`                    |
 | Zhipu      | `ZHIPUAI_API_KEY`      | `zhipu/glm-4`, `zhipu/glm-4-plus`           |
-| Codex CLI  | (ChatGPT subscription) | `codex/gpt-5.2-codex`, `codex/gpt-5.1-codex-max` |
+| Codex CLI  | (ChatGPT subscription) | `codex/gpt-5.3-codex`, `codex/gpt-5.2-codex` |
 | Gemini CLI | (Google account)       | `gemini-cli/gemini-3-pro-preview`, `gemini-cli/gemini-3-flash-preview` |
 
 **Codex CLI Setup:**
@@ -340,7 +340,7 @@ Then present available models to the user using AskUserQuestion with multiSelect
 - `zhipu/glm-4-plus` - Enhanced GLM model
 
 **If Codex CLI is installed, include:**
-- `codex/gpt-5.2-codex` - OpenAI Codex with extended reasoning
+- `codex/gpt-5.3-codex` - OpenAI Codex with extended reasoning
 
 **If Gemini CLI is installed, include:**
 - `gemini-cli/gemini-3-pro-preview` - Google Gemini 3 Pro

--- a/skills/adversarial-spec/SKILL.md
+++ b/skills/adversarial-spec/SKILL.md
@@ -35,7 +35,7 @@ Generate and refine specifications through iterative debate with multiple LLMs u
 
 **Codex CLI Setup:**
 - Install: `npm install -g @openai/codex && codex login`
-- Reasoning effort: `--codex-reasoning` (minimal, low, medium, high, xhigh)
+- Reasoning effort: `--codex-reasoning` (low, medium, high, xhigh). Default: `xhigh` for thorough spec analysis. Codex model default is `medium`.
 - Web search: `--codex-search` (enables web search for current information)
 
 **Gemini CLI Setup:**

--- a/skills/adversarial-spec/scripts/debate.py
+++ b/skills/adversarial-spec/scripts/debate.py
@@ -6,7 +6,7 @@ Sends specs to multiple LLMs for critique using LiteLLM.
 Usage:
     echo "spec" | python3 debate.py critique --models gpt-4o
     echo "spec" | python3 debate.py critique --models gpt-4o,gemini/gemini-2.0-flash,xai/grok-3 --doc-type prd
-    echo "spec" | python3 debate.py critique --models codex/gpt-5.2-codex,gemini/gemini-2.0-flash --doc-type tech
+    echo "spec" | python3 debate.py critique --models codex/gpt-5.3-codex,gemini/gemini-2.0-flash --doc-type tech
     echo "spec" | python3 debate.py critique --models gpt-4o --focus security
     echo "spec" | python3 debate.py critique --models gpt-4o --persona "security engineer"
     echo "spec" | python3 debate.py critique --models gpt-4o --context ./api.md --context ./schema.sql
@@ -28,7 +28,7 @@ Supported providers (set corresponding API key):
     Mistral:    MISTRAL_API_KEY      models: mistral/mistral-large, etc.
     Groq:       GROQ_API_KEY         models: groq/llama-3.3-70b, etc.
     OpenRouter: OPENROUTER_API_KEY   models: openrouter/openai/gpt-4o, openrouter/anthropic/claude-3.5-sonnet, etc.
-    Codex CLI:  (ChatGPT subscription) models: codex/gpt-5.2-codex, codex/gpt-5.1-codex-max
+    Codex CLI:  (ChatGPT subscription) models: codex/gpt-5.3-codex, codex/gpt-5.2-codex
                 Install: npm install -g @openai/codex && codex login
                 Reasoning: --codex-reasoning xhigh (minimal, low, medium, high, xhigh)
 

--- a/skills/adversarial-spec/scripts/providers.py
+++ b/skills/adversarial-spec/scripts/providers.py
@@ -309,7 +309,7 @@ def list_providers():
     # Codex CLI (uses ChatGPT subscription, not API key)
     codex_status = "[installed]" if CODEX_AVAILABLE else "[not installed]"
     print(f"  {'Codex CLI':12} {'(ChatGPT subscription)':24} {codex_status}")
-    print("             Example models: codex/gpt-5.2-codex, codex/gpt-5.1-codex-max")
+    print("             Example models: codex/gpt-5.3-codex, codex/gpt-5.2-codex")
     print(
         "             Reasoning: --codex-reasoning (minimal, low, medium, high, xhigh)"
     )
@@ -383,7 +383,7 @@ def get_available_providers() -> list[tuple[str, Optional[str], str]]:
 
     # Add Codex CLI if available
     if CODEX_AVAILABLE:
-        available.append(("Codex CLI", None, "codex/gpt-5.2-codex"))
+        available.append(("Codex CLI", None, "codex/gpt-5.3-codex"))
 
     # Add Gemini CLI if available
     if GEMINI_CLI_AVAILABLE:

--- a/skills/adversarial-spec/scripts/providers.py
+++ b/skills/adversarial-spec/scripts/providers.py
@@ -34,6 +34,7 @@ MODEL_COSTS = {
     "zhipu/glm-4": {"input": 1.40, "output": 1.40},
     "zhipu/glm-4-plus": {"input": 7.00, "output": 7.00},
     # Codex CLI models (uses ChatGPT subscription, no per-token cost)
+    "codex/gpt-5.3-codex": {"input": 0.0, "output": 0.0},
     "codex/gpt-5.2-codex": {"input": 0.0, "output": 0.0},
     "codex/gpt-5.1-codex-max": {"input": 0.0, "output": 0.0},
     "codex/gpt-5.1-codex-mini": {"input": 0.0, "output": 0.0},

--- a/skills/adversarial-spec/scripts/tests/test_providers.py
+++ b/skills/adversarial-spec/scripts/tests/test_providers.py
@@ -32,6 +32,7 @@ class TestModelCosts:
             "mistral/mistral-large",
             "deepseek/deepseek-chat",
             "zhipu/glm-4",
+            "codex/gpt-5.3-codex",
         ]
         for model in expected:
             assert model in MODEL_COSTS
@@ -742,6 +743,11 @@ class TestGetAvailableProviders:
                     available = get_available_providers()
                     provider_names = [name for name, _, _ in available]
                     assert "Codex CLI" in provider_names
+                    # Verify the default model is gpt-5.3-codex
+                    for name, key, model in available:
+                        if name == "Codex CLI":
+                            assert model == "codex/gpt-5.3-codex"
+                            assert key is None
 
     def test_includes_gemini_cli_when_available(self):
         from providers import get_available_providers
@@ -836,6 +842,19 @@ class TestValidateModelCredentials:
             valid, invalid = validate_model_credentials(["codex/gpt-5.2-codex"])
             assert valid == []
             assert invalid == ["codex/gpt-5.2-codex"]
+
+    def test_validates_codex_gpt53_availability(self):
+        from providers import validate_model_credentials
+
+        with patch("providers.CODEX_AVAILABLE", True):
+            valid, invalid = validate_model_credentials(["codex/gpt-5.3-codex"])
+            assert valid == ["codex/gpt-5.3-codex"]
+            assert invalid == []
+
+        with patch("providers.CODEX_AVAILABLE", False):
+            valid, invalid = validate_model_credentials(["codex/gpt-5.3-codex"])
+            assert valid == []
+            assert invalid == ["codex/gpt-5.3-codex"]
 
     def test_validates_gemini_cli_availability(self):
         from providers import validate_model_credentials


### PR DESCRIPTION
Add support for the new gpt-5.3-codex model in the Codex CLI integration, registered with zero per-token cost and set as the default Codex model.